### PR TITLE
Change ceil to floor when caching credentials

### DIFF
--- a/src/Cache/Adapter.php
+++ b/src/Cache/Adapter.php
@@ -40,7 +40,7 @@ class Adapter implements CacheInterface
         // NOTE: laravel uses minutes (pre 5.8) so this conversion is required
         $version = (float)app()->version();
         if ($version <= 5.8) {
-            $ttl = ceil($ttl / 60);
+            $ttl = floor($ttl / 60);
         }
 
         $this->cache->put($this->makeKey($key), $value, $ttl);


### PR DESCRIPTION
This resolves #2
- change ceil to floor to fix potential cache expiry rounding error.