### PR TITLE
Override env provider to use laravel config

### DIFF
--- a/config/easyaws.php
+++ b/config/easyaws.php
@@ -18,4 +18,10 @@ return [
 
     'cache_store' => env('EASYAWS_CACHE_STORE', 'file'),
 
+    'credentials' => [
+        'key'    => env('AWS_ACCESS_KEY_ID', ''),
+        'secret' => env('AWS_SECRET_ACCESS_KEY', ''),
+        'session_token' => env('AWS_SESSION_TOKEN'),
+    ],
+
 ];

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -2,7 +2,10 @@
 
 namespace EasyAws\Credentials;
 
+use Aws\Credentials\Credentials;
 use Aws\Credentials\CredentialProvider as BaseProvider;
+use Aws\Exception\CredentialsException;
+use GuzzleHttp\Promise;
 
 class CredentialProvider extends BaseProvider
 {
@@ -24,7 +27,9 @@ class CredentialProvider extends BaseProvider
                 );
             }
 
-            return self::reject('Could not find environment variable credentials in easyaws config');
+            return new Promise\RejectedPromise(
+                new CredentialsException('Could not find environment variable credentials in easyaws config')
+            );
         };
     }
 }

--- a/src/Credentials/CredentialProvider.php
+++ b/src/Credentials/CredentialProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EasyAws\Credentials;
+
+use Aws\Credentials\CredentialProvider as BaseProvider;
+
+class CredentialProvider extends BaseProvider
+{
+    /**
+     * Provider that creates credentials from environment variables
+     * AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_SESSION_TOKEN.
+     *
+     * @return callable
+     */
+    public static function env()
+    {
+        return function () {
+            // Use credentials from environment variables, if available
+            $key = config('easyaws.credentials.key');
+            $secret = config('easyaws.credentials.secret');
+            if ($key && $secret) {
+                return Promise\promise_for(
+                    new Credentials($key, $secret, config('easyaws.credentials.session_token'))
+                );
+            }
+
+            return self::reject('Could not find environment variable credentials in easyaws config');
+        };
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,12 +2,12 @@
 
 namespace EasyAws;
 
-use Aws\Credentials\CredentialProvider;
 use Aws\Lambda\LambdaClient;
 use Aws\S3\S3Client;
 use Aws\Sns\SnsClient;
 use Aws\Sqs\SqsClient;
 use EasyAws\Cache\Adapter;
+use EasyAws\Credentials\CredentialProvider;
 use EasyAws\Queue\SqsConnector;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Queue\QueueManager;

--- a/tests/CredentialProviderTest.php
+++ b/tests/CredentialProviderTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EasyAws\Tests;
+
+use Aws\Exception\CredentialsException;
+use Aws\Laravel\AwsServiceProvider;
+use EasyAws\Credentials\CredentialProvider;
+use EasyAws\ServiceProvider;
+use Orchestra\Testbench\TestCase;
+
+class CredentialProviderTest extends TestCase
+{
+    public function testEnvResolution()
+    {
+        config([
+            'easyaws.credentials.key' => 'abcd',
+            'easyaws.credentials.secret' => 'zyxw',
+        ]);
+        $resolver = CredentialProvider::env();
+
+        $credentials = $resolver()->wait();
+
+        $this->assertEquals('abcd', $credentials->getAccessKeyId());
+        $this->assertEquals('zyxw', $credentials->getSecretKey());
+    }
+
+    public function testFailsResolutionWhenEmpty()
+    {
+        $this->expectException(CredentialsException::class);
+        $resolver = CredentialProvider::env();
+
+        $resolver()->wait();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [AwsServiceProvider::class, ServiceProvider::class];
+    }
+}


### PR DESCRIPTION
This resolves #4 by using laravel configuration instead of env vars directly because if config caching is enabled in the
laravel application the env vars will be empty