### PR TITLE
Sync up SqsConnector config with framework

### DIFF
--- a/src/Queue/SqsConnector.php
+++ b/src/Queue/SqsConnector.php
@@ -18,6 +18,11 @@ class SqsConnector implements ConnectorInterface
      */
     public function connect(array $config)
     {
-        return new SqsQueue(app(SqsClient::class), $config['queue']);
+        return new SqsQueue(
+            app(SqsClient::class),
+            $config['queue'],
+            $config['prefix'] ?? '',
+            $config['suffix'] ?? ''
+        );
     }
 }


### PR DESCRIPTION
This should allow us to use SQS queues without having to always specify the full URL. We can set the URL prefix/suffix in config and then just use the queue name which should be a bit simpler