### PR TITLE
Fix SQS timeout regression introduced in v3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.4] - 2025-02-14
+
+### Added
+
+- Set `timeout` to `5.0` for the following AWS services:
+  - DynamoDB
+  - Lambda
+  - S3
+  - SNS
+  - SQS
+
 ## [v3.0.3] - 2025-02-13
 
 ### Changed
@@ -55,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The configuration for the Laravel AWS SDK service provider is now passed to the AWS SDK credential provider. This
   fixes the issue of the STS client always using the `us-east-1` regional endpoint.
 
+[v3.0.4]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.3...v3.0.4
 [v3.0.3]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.2...v3.0.3
 [v3.0.2]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.1...v3.0.2
 [v3.0.1]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.0...v3.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.6] - 2026-04-02
+
+### Fixed
+
+- Restored SQS client `timeout` to `60.0` seconds. Setting it to `5.0` in v3.0.4 broke SQS long-polling, which waits up to 20 seconds for messages.
+
 ## [v3.0.5] - 2025-11-17
 
 ### Added
@@ -72,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The configuration for the Laravel AWS SDK service provider is now passed to the AWS SDK credential provider. This
   fixes the issue of the STS client always using the `us-east-1` regional endpoint.
 
+[v3.0.6]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.5...v3.0.6
+[v3.0.5]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.4...v3.0.5
 [v3.0.4]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.3...v3.0.4
 [v3.0.3]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.2...v3.0.3
 [v3.0.2]: https://github.com/HealthengineAU/laravel-easy-aws/compare/v3.0.1...v3.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.5] - 2025-11-17
+
+### Added
+
+- Added support for the Athena client
+
 ## [v3.0.4] - 2025-02-14
 
 ### Added

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,6 +71,7 @@ class ServiceProvider extends BaseServiceProvider
                     'credentials' => $app->make('easyaws.credentials'),
                     'http' => [
                         'connect_timeout' => 5.0,
+                        'timeout' => 5.0,
                     ],
                 ],
                 $config,

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace EasyAws;
 
+use Aws\Athena\AthenaClient;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Lambda\LambdaClient;
 use Aws\S3\S3Client;
@@ -55,6 +56,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(SnsClient::class, $this->getAwsClientClosure('sns'));
         $this->app->singleton(SqsClient::class, $this->getAwsClientClosure('sqs'));
         $this->app->singleton(DynamoDbClient::class, $this->getAwsClientClosure('dynamoDb'));
+        $this->app->singleton(AthenaClient::class, $this->getAwsClientClosure('athena'));
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -54,7 +54,12 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->singleton(LambdaClient::class, $this->getAwsClientClosure('lambda'));
         $this->app->singleton(S3Client::class, $this->getAwsClientClosure('s3'));
         $this->app->singleton(SnsClient::class, $this->getAwsClientClosure('sns'));
-        $this->app->singleton(SqsClient::class, $this->getAwsClientClosure('sqs'));
+        $this->app->singleton(SqsClient::class, $this->getAwsClientClosure('sqs', [
+            'http' => [
+                'connect_timeout' => 5.0,
+                'timeout' => 60.0, // SQS long-polling waits up to 20s — must not be 5s
+            ],
+        ]));
         $this->app->singleton(DynamoDbClient::class, $this->getAwsClientClosure('dynamoDb'));
         $this->app->singleton(AthenaClient::class, $this->getAwsClientClosure('athena'));
     }

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -34,6 +34,19 @@ class ServiceProviderTest extends TestCase
         $this->assertInstanceOf(SqsClient::class, $this->app->make(SqsClient::class));
     }
 
+    public function testSqsClientHasLongPollingTimeout()
+    {
+        $client = $this->app->make(SqsClient::class);
+
+        $prop = (new \ReflectionClass('Aws\AwsClient'))->getProperty('defaultRequestOptions');
+        $prop->setAccessible(true);
+        $options = $prop->getValue($client);
+
+        // SQS long-polling waits up to 20s — timeout must not be 5s
+        $this->assertSame(60.0, $options['timeout']);
+        $this->assertSame(5.0, $options['connect_timeout']);
+    }
+
     public function testMakeDynamoDbClient()
     {
         $this->assertInstanceOf(DynamoDbClient::class, $this->app->make(DynamoDbClient::class));

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyAws\Tests;
 
+use Aws\Athena\AthenaClient;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Lambda\LambdaClient;
 use Aws\Laravel\AwsServiceProvider;
@@ -36,6 +37,11 @@ class ServiceProviderTest extends TestCase
     public function testMakeDynamoDbClient()
     {
         $this->assertInstanceOf(DynamoDbClient::class, $this->app->make(DynamoDbClient::class));
+    }
+
+    public function testMakeAthenaClient()
+    {
+        $this->assertInstanceOf(AthenaClient::class, $this->app->make(AthenaClient::class));
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
Setting timeout to 5s for SQS breaks long-polling, which waits up to 20 seconds for messages. Restore SQS HTTP timeout to 60s while keeping the 5s connect_timeout that was intentionally tightened.

Also pull in missing releases to this branch